### PR TITLE
Remove hipchat and upgrade ruby

### DIFF
--- a/mac
+++ b/mac
@@ -309,22 +309,6 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
 fi
 ### end mac-components/bundler
 
-if ( echo "mac-components/anvil" | grep -q "$PACKAGE" ); then
-fancy_echo "Installing Anvil..."
-  if [ ! -d "/Applications/Anvil.app" ]; then
-    wget http://sparkler.herokuapp.com/apps/3/download -O /tmp/Anvil.app.zip
-
-    #if [ "$(md5 -r /tmp/Anvil.app.zip)" == "d41d8cd98f00b204e9800998ecf8427e" ]; then
-      echo "Enter your password to install Anvil into /Applications "
-      sudo unzip -o /tmp/Anvil.app.zip -d /Applications/
-      #rm -f /tmp/Anvil.app.zip
-    #fi
-  else
-    fancy_echo "Ignore"
-  fi
-fi
-### end mac-components/anvil
-
 if ( echo "mac-components/hipchat" | grep -q "$PACKAGE" ); then
 fancy_echo "Installing Hipchat..."
   if [ ! -d "/Applications/HipChat.app" ]; then

--- a/mac
+++ b/mac
@@ -280,7 +280,7 @@ fancy_para
 ### end mac-components/compiler-and-libraries
 
 if ( echo "common-components/ruby-environment" | grep -q "$PACKAGE" ); then
-ruby_version="ruby-2.0.0-p645"
+ruby_version="ruby-2.2.6"
 
 fancy_echo "Installing Ruby $ruby_version ..."
   if [ -n "$(rvm list | grep "$ruby_version")" ]; then

--- a/mac
+++ b/mac
@@ -309,17 +309,6 @@ fancy_echo "Configuring Bundler for faster, parallel gem installation ..."
 fi
 ### end mac-components/bundler
 
-if ( echo "mac-components/hipchat" | grep -q "$PACKAGE" ); then
-fancy_echo "Installing Hipchat..."
-  if [ ! -d "/Applications/HipChat.app" ]; then
-    brew cask install hipchat
-    fancy_echo "*** Done"
-  else
-    fancy_echo "*** Installed. Ignore"
-  fi
-fi
-### end mac-components/hipchat
-
 if ( echo "mac-components/imageoptim" | grep -q "$PACKAGE" ); then
 fancy_echo "Installing ImageOptim..."
   if [ ! -d "/Applications/ImageOptim.app" ]; then

--- a/mac-components/mysql
+++ b/mac-components/mysql
@@ -1,7 +1,7 @@
 fancy_echo "Installing MySQL 5.7 ..."
   fancy_echo "Updating brew formula..."
 
-  brew_install_or_upgrade mysql
+  brew_install_or_upgrade mysql@5.7
   brew link mysql --force  >> /tmp/laptop.log 2>&1
   brew services start mysql
 


### PR DESCRIPTION
- Upgrade ruby version to `2.2.6`
- Remove Hipchat
- Remove Anvil
- Specific mysql version to `5.7`. Homebrew pushed MySQL `8.0.11` as an upgrade on Wed, 13 June 2018. So we can't simply run `brew install --env=std --with-mysql sphinx`.